### PR TITLE
Add image width slider plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-# Obsidian Line Width Slider Plugin
-> A plugin for Obsidian that allows you to adjust the editor line width using a simple slider in the status bar.
+# Obsidian Image Width Slider Plugin
+> A plugin for Obsidian that allows you to adjust the width of images in the current note using a simple slider in the status bar.
 
-## Features
+-## Features
 
-- Adjust the line width of the editor using a slider in the status bar.
-- Increase or decrease the line width to customize your editing experience.
+- Adjust the width of images using a slider in the status bar.
+- Increase or decrease image sizes to customize your viewing experience.
 - Simple and intuitive interface for easy usage.
 
 ### Feature: Custom for Individual Files using YAML
 
-With the Obsidian Line Width Slider Plugin, you can now customize the editor width for individual files by specifying an "editor-width" field in the YAML frontmatter of your notes. This feature allows you to have different line widths for different files, giving you greater flexibility in your note-taking and editing experience.
+With the Obsidian Image Width Slider Plugin, you can customize image widths for individual files by specifying an "image-width" field in the YAML frontmatter of your notes. This feature allows you to have different image widths for different files, giving you greater flexibility in your note-taking and editing experience.
 
-#### Setting the Editor Width
+#### Setting the Image Width
 
-To set a custom editor width for a specific file, follow these steps:
+To set a custom image width for a specific file, follow these steps:
 
-1. Open the note for which you want to customize the editor width.
+1. Open the note for which you want to customize the image width.
 
-2. In the YAML frontmatter section at the top of the note, add an "editor-width" field. The value of this field should be a number between 0 and 100, representing the desired editor width as a percentage of the viewport width. For example:
+2. In the YAML frontmatter section at the top of the note, add an "image-width" field. The value of this field should be a number between 0 and 100, representing the desired image width as a percentage of the viewport width. For example:
 
    ```yaml
    ---
    title: My Customized Note
-   editor-width: 75
+   image-width: 75
    ---
    ```
 
@@ -30,26 +30,26 @@ To set a custom editor width for a specific file, follow these steps:
 
 ![Demo GIF](./images/demo-gif-full-size.gif) 
 
-> Here is a brief demo showcasing the basic functionality of the Line Width Slider plugin.
+> Here is a brief demo showcasing the basic functionality of the Image Width Slider plugin.
 
 ## Installation
 
-1. Download the latest release of the plugin from the [Releases](https://github.com/MugishoMp/obsidian-editor-width-slider/releases) page.
+1. Download the latest release of the plugin from the [Releases](https://github.com/MugishoMp/obsidian-image-width-slider/releases) page.
 2. Extract the plugin folder from the downloaded ZIP file.
 3. Copy the plugin folder into your Obsidian vault's `.obsidian/plugins` directory.
 4. Launch Obsidian and open the settings.
-5. Navigate to the "Community Plugins" tab and enable the "Line Width Slider" plugin.
-6. Enjoy using the Line Width Slider in the status bar to adjust the editor line width.
+5. Navigate to the "Community Plugins" tab and enable the "Image Width Slider" plugin.
+6. Enjoy using the Image Width Slider in the status bar to adjust the image widths.
 
 ## Usage
 
 1. Once the plugin is enabled, you will see a slider in the status bar.
-2. Drag the slider to the left or right to increase or decrease the editor line width.
-3. The changes will be applied to the editor in real-time.
+2. Drag the slider to the left or right to increase or decrease the width of images.
+3. The changes will be applied to all images in the current note in real-time.
 
 ## Feedback and Support
 
-If you encounter any issues or have suggestions for improvements, please create a new [issue](https://github.com/MugishoMp/obsidian-editor-width-slider/issues) on the GitHub repository.
+If you encounter any issues or have suggestions for improvements, please create a new [issue](https://github.com/MugishoMp/obsidian-image-width-slider/issues) on the GitHub repository.
 
 ## Support Me
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-	"id": "editor-width-slider",
-	"name": "Editor Width Slider",
+       "id": "image-width-slider",
+       "name": "Image Width Slider",
 	"version": "1.0.5",
 	"minAppVersion": "0.15.0",
-	"description": "Customize Obsidian's editor width with a slider for a tailored editing experience.",
+       "description": "Resize images in your notes with an easy to use slider.",
 	"author": "@MugishoMp",
 	"authorUrl": "https://github.com/MugishoMp",
 	"fundingUrl": "https://www.paypal.com/donate/?hosted_button_id=E4APAMMHVJE4N",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "obsidian-sample-plugin",
+       "name": "obsidian-image-width-slider",
 	"version": "1.0.0",
-	"description": "This is a sample plugin for Obsidian (https://obsidian.md)",
+       "description": "Obsidian plugin to resize images using a slider",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,12 +4,12 @@ import {
 
 
 import {
-	DEFAULT_SETTINGS,
-	EditorWidthSliderSettingTab
+        DEFAULT_SETTINGS,
+        ImageWidthSliderSettingTab
 } from "./settings/settings";
 
-import { 
-	EditorWidthSliderSettings 
+import {
+        ImageWidthSliderSettings
 } from './types/settings';
 
 
@@ -18,8 +18,8 @@ import {
 } from './modal/warning';
 
 // ---------------------------- Plugin Class -----------------------------------
-export default class EditorWidthSlider extends Plugin {
-	settings: EditorWidthSliderSettings;
+export default class ImageWidthSlider extends Plugin {
+        settings: ImageWidthSliderSettings;
 
 	// most important function, this gets executed everytime the plugin is first 
 	// loaded, e.g. when obsidian starts, or when the user just installed the 
@@ -29,13 +29,13 @@ export default class EditorWidthSlider extends Plugin {
 		
 		this.addStyle();
 
-		this.app.workspace.on('file-open', () => {
-			this.updateEditorStyleYAML();
-		});
+                this.app.workspace.on('file-open', () => {
+                        this.updateImageStyleYAML();
+                });
 
-		this.createSlider();
+                this.createSlider();
 
-		this.addSettingTab(new EditorWidthSliderSettingTab(this.app, this));
+                this.addSettingTab(new ImageWidthSliderSettingTab(this.app, this));
 
 	}
 
@@ -45,7 +45,7 @@ export default class EditorWidthSlider extends Plugin {
 	// }
 
 	onunload() {
-		this.cleanUpResources();
+                this.cleanUpResources();
 	}
 	
 	// ---------------------------- SLIDER -------------------------------------
@@ -53,8 +53,8 @@ export default class EditorWidthSlider extends Plugin {
 
 		// Create the slider element
 		const slider = document.createElement('input');
-		slider.classList.add('editor-width-slider');
-		slider.id = 'editor-width-slider';
+                slider.classList.add('image-width-slider');
+                slider.id = 'image-width-slider';
 		slider.type = 'range';
 		slider.min = '0';
 		slider.max = '100';
@@ -69,7 +69,7 @@ export default class EditorWidthSlider extends Plugin {
 			this.settings.sliderPercentage = value.toString();
 
 			this.saveSettings();
-			this.updateEditorStyle();
+                        this.updateImageStyle();
 			sliderValueText.textContent = value.toString();
 			console.log('Slider value:', value);
 			// Perform any actions based on the slider value
@@ -78,8 +78,8 @@ export default class EditorWidthSlider extends Plugin {
 		// Create the text element for displaying the slider value
 		const sliderValueText = document.createElement('span');
 		sliderValueText.textContent = slider.value;
-		sliderValueText.classList.add('editor-width-slider-value');
-		sliderValueText.id = 'editor-width-slider-value';
+                sliderValueText.classList.add('image-width-slider-value');
+                sliderValueText.id = 'image-width-slider-value';
 
 		// Add the CSS properties to the span element
 		sliderValueText.style.color = 'white';
@@ -107,7 +107,7 @@ export default class EditorWidthSlider extends Plugin {
 
 		// Add a click event listener to the slider value text
 		sliderValueText.addEventListener('click', () => {
-			this.resetEditorWidth()
+                        this.resetImageWidth()
 		});
 
 		// Create the status bar item
@@ -118,18 +118,18 @@ export default class EditorWidthSlider extends Plugin {
 	}
 	// ---------------------------- SLIDER -------------------------------------
 
-	cleanUpResources() {
-		this.resetEditorWidth();
-	}
+        cleanUpResources() {
+                this.resetImageWidth();
+        }
 
-	resetEditorWidth() {
+        resetImageWidth() {
 		// const widthInPixels = 400 + value * 10;
 		this.settings.sliderPercentage = this.settings.sliderPercentageDefault;
 
 		// get the custom css element
-		const styleElements = document.getElementsByClassName('editor-width-slider');
-		const slider = document.getElementById('editor-width-slider') as HTMLInputElement;
-		const sliderValue = document.getElementById('editor-width-slider-value') as HTMLInputElement;
+                const styleElements = document.getElementsByClassName('image-width-slider');
+                const slider = document.getElementById('image-width-slider') as HTMLInputElement;
+                const sliderValue = document.getElementById('image-width-slider-value') as HTMLInputElement;
 		if (slider) {
 			if (sliderValue) {
 				slider.value = this.settings.sliderPercentageDefault;
@@ -137,56 +137,54 @@ export default class EditorWidthSlider extends Plugin {
 			}
 		}
 
-		this.saveSettings();
-		this.updateEditorStyleYAML();
+                this.saveSettings();
+                this.updateImageStyleYAML();
 	}
 
 	// add element that contains all of the styling elements we need
 	addStyle() {
 		// add a css block for our settings-dependent styles
-		const css = document.createElement('style');
-		css.id = 'additional-editor-css';
+                const css = document.createElement('style');
+                css.id = 'additional-image-css';
 		document.getElementsByTagName("head")[0].appendChild(css);
 
 		// add the main class
-		document.body.classList.add('additional-editor-css');
+                document.body.classList.add('additional-image-css');
 
 		// update the style with the settings-dependent styles
-		// this.updateEditorStyle();
+        // this.updateImageStyle();
 	}
 
 	
 	// update the styles (at the start, or as the result of a settings change)
-	updateEditorStyle() {
+        updateImageStyle() {
 		// get the custom css element
-		const styleElement = document.getElementById('additional-editor-css');
-		if (!styleElement) throw "additional-editor-css element not found!";
+                const styleElement = document.getElementById('additional-image-css');
+                if (!styleElement) throw "additional-image-css element not found!";
 		else {
 
-		styleElement.innerText = `
-			body {
-   				--line-width: calc(700px + 10 * ${this.settings.sliderPercentage}px) !important;
-			  	--file-line-width: calc(700px + 10 * ${this.settings.sliderPercentage}px) !important;
-			}
-		`;
+                styleElement.innerText = `
+                        .markdown-preview-view img {
+                                max-width: ${this.settings.sliderPercentage}% !important;
+                        }
+                `;
 
 		}
 	}
 
 
 	// update the styles (at the start, or as the result of a settings change)
-	updateEditorStyleYAMLHelper(editorWidth: any) {
+        updateImageStyleYAMLHelper(imageWidth: any) {
 		// get the custom css element
-		const styleElement = document.getElementById('additional-editor-css');
-		if (!styleElement) throw "additional-editor-css element not found!";
+                const styleElement = document.getElementById('additional-image-css');
+                if (!styleElement) throw "additional-image-css element not found!";
 		else {
 
-		styleElement.innerText = `
-			body {
-   				--line-width: calc(100px + ${editorWidth}vw) !important;
-			  	--file-line-width: calc(100px + ${editorWidth}vw) !important;
-			}
-		`;
+                styleElement.innerText = `
+                        .markdown-preview-view img {
+                                max-width: ${imageWidth}vw !important;
+                        }
+                `;
 
 		}
 	}
@@ -197,7 +195,7 @@ export default class EditorWidthSlider extends Plugin {
 		return this.pattern.test(inputString);
 	}
 
-	updateEditorStyleYAML() {
+        updateImageStyleYAML() {
 		// if there is yaml frontmatter, take info from yaml, otherwise take info from slider
 		const file = this.app.workspace.getActiveFile() as TFile; // Currently Open Note
 		if(file.name) {
@@ -206,21 +204,21 @@ export default class EditorWidthSlider extends Plugin {
 			if (metadata) {
 				if (metadata.frontmatter) {
 					try {
-						if (metadata.frontmatter["editor-width"]) {
-							if (this.validateString(metadata.frontmatter["editor-width"])) {
-								this.updateEditorStyleYAMLHelper(metadata.frontmatter["editor-width"]);
-							} else {
-								new WarningModal(this.app).open();
-								throw new Error("Editor width must be a number from 0 to 100.");
-							}
-						} else {
-							this.updateEditorStyle();
-						}
-					} catch (e) {
+                                                if (metadata.frontmatter["image-width"]) {
+                                                        if (this.validateString(metadata.frontmatter["image-width"])) {
+                                                                this.updateImageStyleYAMLHelper(metadata.frontmatter["image-width"]);
+                                                        } else {
+                                                                new WarningModal(this.app).open();
+                                                                throw new Error("Image width must be a number from 0 to 100.");
+                                                        }
+                                                } else {
+                                                        this.updateImageStyle();
+                                                }
+                                        } catch (e) {
 						console.error("Error:", e.message);
 					}
 				} else {
-					this.updateEditorStyle();
+                                        this.updateImageStyle();
 				}
 			}
 		}
@@ -230,10 +228,10 @@ export default class EditorWidthSlider extends Plugin {
 	// update the styles (at the start, or as the result of a settings change)
 	updateSliderStyle() {
 		// get the custom css element
-		const styleElements = document.getElementsByClassName('editor-width-slider');
+                const styleElements = document.getElementsByClassName('image-width-slider');
 		
 		if (styleElements.length === 0) {
-			throw new Error("editor-width-slider-value element not found!");
+                        throw new Error("image-width-slider-value element not found!");
 		} else {
 			// Access the first element in the collection and modify its style
 			const styleElement = styleElements[0] as HTMLElement;

--- a/src/modal/warning.ts
+++ b/src/modal/warning.ts
@@ -7,7 +7,7 @@ export class WarningModal extends Modal {
 
   onOpen() {
     const { contentEl } = this;
-    contentEl.setText("Editor width must be a number from 0 to 100!");
+    contentEl.setText("Image width must be a number from 0 to 100!");
   }
 
   onClose() {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -4,22 +4,22 @@ import {
 	Setting,
 } from 'obsidian';
 
-import EditorWidthSlider from "../main";
-import { EditorWidthSliderSettings } from 'src/types/settings';
+import ImageWidthSlider from "../main";
+import { ImageWidthSliderSettings } from 'src/types/settings';
 
 // ---------------------------- Storing Information ----------------------------
 // the default value of the thing you want to store 
-export const DEFAULT_SETTINGS: EditorWidthSliderSettings = {
-	sliderPercentage: '20',
-	sliderPercentageDefault: '20',
-	sliderWidth: '150'
-}
+export const DEFAULT_SETTINGS: ImageWidthSliderSettings = {
+        sliderPercentage: '50',
+        sliderPercentageDefault: '50',
+        sliderWidth: '150'
+};
 // ---------------------------- Storing Information ----------------------------
 
-export class EditorWidthSliderSettingTab extends PluginSettingTab {
-	plugin: EditorWidthSlider;
+export class ImageWidthSliderSettingTab extends PluginSettingTab {
+        plugin: ImageWidthSlider;
 
-	constructor(app: App, plugin: EditorWidthSlider) {
+        constructor(app: App, plugin: ImageWidthSlider) {
 		super(app, plugin);
 		this.plugin = plugin;
 	}
@@ -55,7 +55,7 @@ export class EditorWidthSliderSettingTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Note:')
-            .setDesc('The field should be named "editor-width" in the YAML frontmatter of the note in order to customize the editor width of that repective note. It won\'t work globally for all notes unless you specify it in each note\'s frontmatter.');
+            .setDesc('The field should be named "image-width" in the YAML frontmatter of the note in order to customize the image width of that respective note. It won\'t work globally for all notes unless you specify it in each note\'s frontmatter.');
 
 	}
 }

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,6 +1,6 @@
 // This plugin will store a single string
-export interface EditorWidthSliderSettings {
-	sliderPercentage: string;
-	sliderPercentageDefault: string;
-	sliderWidth: string;
+export interface ImageWidthSliderSettings {
+        sliderPercentage: string;
+        sliderPercentageDefault: string;
+        sliderWidth: string;
 }


### PR DESCRIPTION
## Summary
- rename plugin to **Image Width Slider**
- add new setting interface and YAML key `image-width`
- adjust slider to control image width instead of editor width
- update settings tab and warning modal
- update docs for new plugin name and usage

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a9aff633c832d8c9ff42c07c896b8