### PR TITLE
Prevent conflicts with Image Toolkit plugin

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -185,11 +185,11 @@ export default class ImageWidthSlider extends Plugin {
                 const styleElement = document.getElementById('additional-image-css');
                 if (!styleElement) throw "additional-image-css element not found!";
                 const unit = this.settings.unit;
-                styleElement.innerText = `
-                        .image-width-slider-target img {
-                                width: ${this.settings.sliderPercentage}${unit} !important;
-                        }
-                `;
+styleElement.innerText = `
+.image-width-slider-target img:not(.oit-img-view):not(.oit-img):not(.gallery-img) {
+width: ${this.settings.sliderPercentage}${unit} !important;
+}
+`;
         }
 
 
@@ -202,7 +202,7 @@ export default class ImageWidthSlider extends Plugin {
                 if (!styleElement) throw "additional-image-css element not found!";
                 const unit = this.settings.unit;
                 styleElement.innerText = `
-                        .image-width-slider-target img {
+                        .image-width-slider-target img:not(.oit-img-view):not(.oit-img):not(.gallery-img) {
                                 width: ${imageWidth}${unit} !important;
                         }
                 `;

--- a/src/main.ts
+++ b/src/main.ts
@@ -186,7 +186,7 @@ export default class ImageWidthSlider extends Plugin {
                 if (!styleElement) throw "additional-image-css element not found!";
                 const unit = this.settings.unit;
 styleElement.innerText = `
-.image-width-slider-target img:not(.oit-img-view):not(.oit-img):not(.gallery-img) {
+.image-width-slider-target img:not(.oit-img-view):not(.oit-img):not(.gallery-img):not([class*="widget"]) {
 width: ${this.settings.sliderPercentage}${unit} !important;
 }
 `;
@@ -202,7 +202,7 @@ width: ${this.settings.sliderPercentage}${unit} !important;
                 if (!styleElement) throw "additional-image-css element not found!";
                 const unit = this.settings.unit;
                 styleElement.innerText = `
-                        .image-width-slider-target img:not(.oit-img-view):not(.oit-img):not(.gallery-img) {
+                        .image-width-slider-target img:not(.oit-img-view):not(.oit-img):not(.gallery-img):not([class*="widget"]) {
                                 width: ${imageWidth}${unit} !important;
                         }
                 `;


### PR DESCRIPTION
## Summary
- avoid applying width slider styles to elements used by the Image Toolkit plugin

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b0c8e102c832d99ea2da048c438a2